### PR TITLE
"Detriments", Benefits that get deactivated upon reaching the threshold

### DIFF
--- a/src/main/java/com/tarinoita/solsweetpotato/SOLSweetPotatoConfig.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/SOLSweetPotatoConfig.java
@@ -151,7 +151,11 @@ public final class SOLSweetPotatoConfig {
 							+" at the corresponding diversity threshold defined the list above. For example, the first entry in\n"
 							+" this list will be applied when the player's food diversity reaches the number in the first entry in\n"
 							+" the threshold list above.\n"
-							+" Each benefit is a string with the following form: [type],[registry name],[value] (without the brackets)\n"
+							+" A benefit can also be marked as a detriment. In that case, its activation is reversed.\n"
+							+" A detriment is applied while the player has less diversity than the threshold,\n"
+							+" and will be removed when the threshold is reached.\n"
+							+" Each benefit is a string with the following form: [+/-][type],[registry name],[value] (without the brackets)\n"
+							+" A leading plus (or the of a symbol) denotes a benefit, while a minus denotes a detriment.\n"
 							+" The type can either be 'attribute' for attribute modifiers or 'effect' for potion effects\n"
 							+" Registry names for common vanila attributes are \n"
 							+" generic.max_health, generic.knockback_resistance, generic.movement_speed, generic.luck, \n"
@@ -165,6 +169,8 @@ public final class SOLSweetPotatoConfig {
 							+" Make sure that you have NO SPACES!\n"
 							+" As an example, 'attribute,generic.max_health,2;effect,strength,1' will give both +2 max hp\n"
 							+" and Strength II at the corresponding threshold.\n"
+							+" 'attribute,generic.attack_damage,1;-effect,slowness,0' will give +1 attack damage at the corresponding threshold\n"
+							+" and Slowness I below the corresponding threshold.\n"
 							+"\n")
 					.defineList("benefitsUnparsed", Lists.newArrayList(
 							"attribute,generic.max_health,2",

--- a/src/main/java/com/tarinoita/solsweetpotato/client/gui/FoodBookScreen.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/client/gui/FoodBookScreen.java
@@ -110,12 +110,16 @@ public final class FoodBookScreen extends Screen implements PageFlipButton.Pagea
 		addPages("food_queue_label", foods);
 
 		Pair<List<BenefitInfo>, List<BenefitInfo>> benefits = BenefitsHandler.getBenefitInfo(foodDiversity, foodEaten);
-		List<BenefitInfo> activeBenefits = benefits.getKey();
-		List<BenefitInfo> inactiveBenefits = benefits.getValue();
+		List<BenefitInfo> activeBenefits = benefits.getKey().stream().filter(bi -> !bi.detriment).toList();
+		List<BenefitInfo> inactiveDetriments = benefits.getKey().stream().filter(bi -> bi.detriment).toList();
+		List<BenefitInfo> inactiveBenefits = benefits.getValue().stream().filter(bi -> !bi.detriment).toList();
+		List<BenefitInfo> activeDetriments = benefits.getValue().stream().filter(bi -> bi.detriment).toList();
 		
+		addPages("active_detriments_header", activeDetriments, inactiveRed);
 		addPages("active_benefits_header", activeBenefits, activeGreen);
 
 		if (SOLSweetPotatoConfig.shouldShowInactiveBenefits()) {
+			addPages("inactive_detriments_header", inactiveDetriments, activeGreen);
 			addPages("inactive_benefits_header", inactiveBenefits, inactiveRed);
 		}
 	}

--- a/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/AttributeBenefit.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/AttributeBenefit.java
@@ -3,6 +3,7 @@ package com.tarinoita.solsweetpotato.tracking.benefits;
 import com.tarinoita.solsweetpotato.ConfigHandler;
 import com.tarinoita.solsweetpotato.SOLSweetPotato;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.DoubleTag;
 import net.minecraft.nbt.StringTag;
@@ -26,8 +27,8 @@ public final class AttributeBenefit extends Benefit {
     private Attribute attribute;
     private final boolean isMaxHealth;
 
-    public AttributeBenefit(String name, double value, double threshold) {
-        super("attribute", name, value, threshold);
+    public AttributeBenefit(String name, double value, double threshold, boolean detriment) {
+        super("attribute", name, value, threshold, detriment);
 
         id = UUID.randomUUID();
 
@@ -36,8 +37,8 @@ public final class AttributeBenefit extends Benefit {
         isMaxHealth = name.equals("generic.max_health");
     }
 
-    public AttributeBenefit(String name, double value, double threshold, String uuid) {
-        super("attribute", name, value, threshold);
+    public AttributeBenefit(String name, double value, double threshold, String uuid, boolean detriment) {
+        super("attribute", name, value, threshold, detriment);
 
         id = UUID.fromString(uuid);
 
@@ -121,12 +122,14 @@ public final class AttributeBenefit extends Benefit {
         DoubleTag v = DoubleTag.valueOf(value);
         StringTag uuid = StringTag.valueOf(id.toString());
         DoubleTag thresh = DoubleTag.valueOf(threshold);
+        ByteTag detr = ByteTag.valueOf((byte) (detriment ? 1 : 0));
 
         tag.put("type", type);
         tag.put("name", n);
         tag.put("value", v);
         tag.put("id", uuid);
         tag.put("threshold", thresh);
+        tag.put("detriment", detr);
 
         return tag;
     }
@@ -140,7 +143,8 @@ public final class AttributeBenefit extends Benefit {
         double v = tag.getDouble("value");
         String uuid = tag.getString("id");
         double thresh = tag.getDouble("threshold");
+        boolean detr = tag.getByte("detriment") == 1;
 
-        return new AttributeBenefit(n, v, thresh, uuid);
+        return new AttributeBenefit(n, v, thresh, uuid, detr);
     }
 }

--- a/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/Benefit.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/Benefit.java
@@ -9,13 +9,15 @@ public abstract class Benefit {
     protected final String name;
     protected final double value;
     protected boolean invalid = false;
+    protected boolean detriment = false;
     protected final double threshold;
 
-    public Benefit(String benefitType, String name, double value, double threshold) {
+    public Benefit(String benefitType, String name, double value, double threshold, boolean detriment) {
         this.benefitType = benefitType;
         this.name = name;
         this.value = value;
         this.threshold = threshold;
+        this.detriment = detriment;
     }
 
     public abstract void applyTo(Player player);
@@ -24,6 +26,10 @@ public abstract class Benefit {
 
     public boolean isInvalid() {
         return invalid;
+    }
+
+    public boolean isDetriment() {
+        return detriment;
     }
 
     protected void markInvalid() {

--- a/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/BenefitInfo.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/BenefitInfo.java
@@ -5,11 +5,13 @@ public class BenefitInfo {
     public String name;
     public double value;
     public double threshold;
+    public boolean detriment;
 
-    public BenefitInfo(String type, String name, double value, double threshold) {
+    public BenefitInfo(String type, String name, double value, double threshold, boolean detriment) {
         this.type = type;
         this.name = name;
         this.value = value;
         this.threshold = threshold;
+        this.detriment = detriment;
     }
 }

--- a/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/BenefitsHandler.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/BenefitsHandler.java
@@ -142,13 +142,16 @@ public class BenefitsHandler {
             }
             if (active_threshold >= thresh) {
                 benefitsList.get(i).forEach(b -> activeBenefitInfo.add(
-                        new BenefitInfo(b.getType(), b.getName(), b.getValue(), thresh)));
+                        new BenefitInfo(b.getType(), b.getName(), b.getValue(), thresh, b.isDetriment())));
             }
             else {
                 benefitsList.get(i).forEach(b -> inactiveBenefitInfo.add(
-                        new BenefitInfo(b.getType(), b.getName(), b.getValue(), thresh)));
+                        new BenefitInfo(b.getType(), b.getName(), b.getValue(), thresh, b.isDetriment())));
             }
         }
+
+        activeBenefitInfo.sort((bi1, bi2) -> Boolean.compare(bi1.detriment, bi2.detriment));
+        inactiveBenefitInfo.sort((bi1, bi2) -> Boolean.compare(bi1.detriment, bi2.detriment));
 
         return new ImmutablePair<>(activeBenefitInfo, inactiveBenefitInfo);
     }

--- a/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/BenefitsHandler.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/BenefitsHandler.java
@@ -58,12 +58,14 @@ public class BenefitsHandler {
             if (i >= benefitsList.size()) {
                 return;
             }
-            if (diversity >= thresh) {
-                benefitsList.get(i).forEach(b -> b.applyTo(player));
-            }
-            else {
-                benefitsList.get(i).forEach(b -> b.removeFrom(player));
-            }
+            benefitsList.get(i).forEach(b -> {
+                // != acts as XOR
+                if((diversity >= thresh) != b.isDetriment()) {
+                    b.applyTo(player);
+                } else {
+                    b.removeFrom(player);
+                }
+            });
         }
     }
 

--- a/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/EffectBenefit.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/tracking/benefits/EffectBenefit.java
@@ -2,6 +2,7 @@ package com.tarinoita.solsweetpotato.tracking.benefits;
 
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.DoubleTag;
 import net.minecraft.nbt.StringTag;
@@ -21,8 +22,8 @@ public final class EffectBenefit extends Benefit{
     private final int DEFAULT_DURATION = 300;
     private final int REAPPLY_DURATION = 200;
 
-    public EffectBenefit(String name, double value, double threshold) {
-        super("effect", name, value, threshold);
+    public EffectBenefit(String name, double value, double threshold, boolean detriment) {
+        super("effect", name, value, threshold, detriment);
     }
 
     public void applyTo(Player player) {
@@ -96,11 +97,13 @@ public final class EffectBenefit extends Benefit{
         StringTag n = StringTag.valueOf(name);
         DoubleTag v = DoubleTag.valueOf(value);
         DoubleTag thresh = DoubleTag.valueOf(threshold);
+        ByteTag detr = ByteTag.valueOf((byte) (detriment ? 1 : 0));
 
         tag.put("type", type);
         tag.put("name", n);
         tag.put("value", v);
         tag.put("threshold", thresh);
+        tag.put("detriment", detr);
 
         return tag;
     }
@@ -113,7 +116,8 @@ public final class EffectBenefit extends Benefit{
         String n = tag.getString("name");
         double v = tag.getDouble("value");
         double thresh = tag.getDouble("threshold");
+        boolean detr = tag.getByte("detriment") == 1;
 
-        return new EffectBenefit(n, v, thresh);
+        return new EffectBenefit(n, v, thresh, detr);
     }
 }

--- a/src/main/java/com/tarinoita/solsweetpotato/utils/BenefitsParser.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/utils/BenefitsParser.java
@@ -18,6 +18,15 @@ public class BenefitsParser {
             List<Benefit> thresholdBenefits = new ArrayList<>();
 
             for (String benefitString : thresholdBenefitsString) {
+                boolean is_detriment = false;
+                switch(benefitString.charAt(0)){
+                    case '-':
+                        is_detriment = true;
+                    case '+':
+                        benefitString = benefitString.substring(1);
+                    default:
+                        break;
+                }
                 String[] benefitArgs = benefitString.split(",", 0);
                 int len = benefitArgs.length;
 
@@ -46,10 +55,10 @@ public class BenefitsParser {
                 }
 
                 if (benefitType.equals("attribute")) {
-                    thresholdBenefits.add(new AttributeBenefit(benefitName, benefitValue, thresh));
+                    thresholdBenefits.add(new AttributeBenefit(benefitName, benefitValue, thresh, is_detriment));
                 }
                 else if (benefitType.equals("effect")) {
-                    thresholdBenefits.add(new EffectBenefit(benefitName, benefitValue, thresh));
+                    thresholdBenefits.add(new EffectBenefit(benefitName, benefitValue, thresh, is_detriment));
                 }
             }
             allBenefits.add(thresholdBenefits);

--- a/src/main/resources/assets/solsweetpotato/lang/en_us.json
+++ b/src/main/resources/assets/solsweetpotato/lang/en_us.json
@@ -24,6 +24,8 @@
 	"gui.solsweetpotato.food_book.stats.min_warning2": "to activate benefits",
 	"gui.solsweetpotato.food_book.active_benefits_header": "Active Benefits",
 	"gui.solsweetpotato.food_book.inactive_benefits_header": "Inactive Benefits",
+	"gui.solsweetpotato.food_book.active_detriments_header": "Active Detriments",
+	"gui.solsweetpotato.food_book.inactive_detriments_header": "Inactive Detriments",
 	"gui.solsweetpotato.food_book.benefits.threshold_label": "Threshold",
 	"gui.solsweetpotato.food_book.benefits.active_tooltip": "Because your food diversity is greater than this threshold, this benefit is active.",
 	"gui.solsweetpotato.food_book.benefits.inactive_tooltip": "If your food diversity becomes greater than this threshold, this benefit will activate.",


### PR DESCRIPTION
I have implemented the ability to configure benefits that get deactivated when the threshold is reached, which I call "detriments".

The motivation is to make it easier to make underfed players weaker.
With the config as-is, it is not really possible to add, for example, a slow effect at low food diversity.
This can also be used to lower the maximum health in a more intuitive fashion.
Before, it was necessary to put a negative benefit at threshold 0, and then add positive benefits at higher thresholds.
With detriments, the same effect can be achieved without the threshold 0.

I have implmented this using a single additional field on benefits.
It stores a boolean denoting whether this benefit is a detriment.
In the application of benefits, an XOR is used to decide whether the given benefit/detriment needs to be applied or removed.

The food book also has two additional categories, "Inactive Detriments" and "Active Detriments". They work identically to the previous categories, just limited to the detriments. The benefit lists do not list the detriments.

A detriment is marked by a leading '-' in the config file.
A leading '+' can be used to make a benefit explicit, but is not necessary.
The new syntax is fully compatible with old config files. Their functionality is not changed.
The docstring in the config is modified to explain the syntax.

I have tried my best to make as few changes as possible. The implementation and naming tries to copy the established conventions.