### PR TITLE
Fix recipe unlock condition

### DIFF
--- a/src/main/resources/data/solsweetpotato/advancements/recipes/food_book.json
+++ b/src/main/resources/data/solsweetpotato/advancements/recipes/food_book.json
@@ -10,7 +10,7 @@
 			"trigger": "minecraft:inventory_changed",
 			"conditions": {
 				"items": [
-					{ "item": "minecraft:potato" }
+					{ "items": ["minecraft:potato"] }
 				]
 			}
 		},
@@ -18,7 +18,7 @@
 			"trigger": "minecraft:inventory_changed",
 			"conditions": {
 				"items": [
-					{ "item": "minecraft:book" }
+					{ "items": ["minecraft:book"] }
 				]
 			}
 		},


### PR DESCRIPTION
In Minecraft 1.19.2 (and likely every other version), picking up any item immediately unlocks the recipe for the food book. This is unintentional, since the advancements specify only certain items should unlock it. This PR fixes that.

According to the [Minecraft wiki](https://minecraft.fandom.com/wiki/Advancement/JSON_format#minecraft:inventory_changed), the objects in the `conditions.items` array should contain a key named "items", not "item", whose value is an array of strings, not a single string.